### PR TITLE
feat: try catch custom handler

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,3 +2,5 @@
 . "$(dirname "$0")/_/husky.sh"
 
 yarn lint-staged
+
+yarn test

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "land",
-  "version": "0.1.0",
+  "version": "1.22.22",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "lint:fix": "next lint --fix",
     "prepare": "husky install",
     "export": "next export",
-    "format": "prettier --write ."
+    "format": "prettier --write .",
+    "test": "jest"
   },
   "dependencies": {
     "@chakra-ui/icons": "2.1.1",
@@ -34,6 +35,7 @@
   },
   "devDependencies": {
     "@ianvs/prettier-plugin-sort-imports": "3.4.2",
+    "@jest/globals": "^29.7.0",
     "@types/node": "18.0.0",
     "@types/react": "18.2.47",
     "@types/react-copy-to-clipboard": "^5.0.7",
@@ -49,12 +51,24 @@
     "eslint-plugin-react": "7.28.0",
     "eslint-plugin-react-hooks": "4.3.0",
     "husky": "7.0.4",
+    "jest": "^29.7.0",
     "lint-staged": "12.3.2",
     "prettier": "2.7.1",
+    "ts-jest": "^29.2.5",
     "typescript": "4.7.4"
   },
   "lint-staged": {
     "*.{js,ts,tsx}": "eslint --fix",
     "*.{js,css,md,ts,tsx}": "prettier --write"
+  },
+  "jest": {
+    "preset": "ts-jest",
+    "testEnvironment": "node",
+    "transform": {
+      "node_modules/variables/.+\\.(j|t)sx?$": "ts-jest"
+    },
+    "transformIgnorePatterns": [
+      "node_modules/(?!variables/.*)"
+    ]
   }
 }

--- a/src/lib/catchy.test.ts
+++ b/src/lib/catchy.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from '@jest/globals';
+
+import { catchy } from './catchy';
+
+async function getUser() {
+  throw new Error('user not found');
+}
+
+async function getMetadata() {
+  return Promise.resolve('metadata found!');
+}
+
+describe('Catchy Module - Single Function', () => {
+  test('Given a promise that throws an error, when calling catchy, then it should return the error', async () => {
+    const [err, user] = await catchy(getUser());
+    expect(err).toBeInstanceOf(Error);
+    expect(user).toBeUndefined();
+  });
+
+  test('Given a promise that resolves, when calling catchy, then it should return the value', async () => {
+    const [err, metadata] = await catchy(getMetadata());
+    expect(err).toBeUndefined();
+    expect(metadata).toBe('metadata found!');
+  });
+
+  test('Given a promise that throws an error, when calling catchy with an error to catch, then it should return the error', async () => {
+    const [err, user] = await catchy(getUser(), [Error]);
+    expect(err).toBeInstanceOf(Error);
+    expect(user).toBeUndefined();
+  });
+});
+
+describe('Catchy Module - Multiple Functions', () => {
+  test('Given a multiple function calls, when some of them throw an error, then it should return the first error', async () => {
+    const [errMetadata, metadata] = await catchy(getMetadata());
+    expect(errMetadata).toBeUndefined();
+    expect(metadata).toBe('metadata found!');
+
+    const [errUser, user] = await catchy(getUser());
+    expect(errUser).toBeInstanceOf(Error);
+    expect(user).toBeUndefined();
+  });
+
+  test('Given a multiple function calls, when some of them throw an error, then it should return the first error', async () => {
+    const [errUser, user] = await catchy(getUser());
+    expect(errUser).toBeInstanceOf(Error);
+    expect(user).toBeUndefined();
+
+    const [errMetadata, metadata] = await catchy(getMetadata());
+    expect(errMetadata).toBeUndefined();
+    expect(metadata).toBe('metadata found!');
+  });
+});

--- a/src/lib/catchy.test.ts
+++ b/src/lib/catchy.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from '@jest/globals';
+import { describe, expect, jest, test } from '@jest/globals';
 
 import { catchy } from './catchy';
 
@@ -49,5 +49,33 @@ describe('Catchy Module - Multiple Functions', () => {
     const [errMetadata, metadata] = await catchy(getMetadata());
     expect(errMetadata).toBeUndefined();
     expect(metadata).toBe('metadata found!');
+  });
+});
+
+describe('Catchy Module - Verbose Mode', () => {
+  test('Given a promise that throws an error, when calling catchy with verbose mode, then it should return the error and log it', async () => {
+    const consoleError = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+    const [err, user] = await catchy(getUser(), undefined, true);
+
+    expect(err).toBeInstanceOf(Error);
+    expect(user).toBeUndefined();
+    expect(consoleError).toHaveBeenCalled();
+
+    consoleError.mockRestore();
+  });
+
+  test('Given a promise that resolves, when calling catchy with verbose mode, then it should return the value', async () => {
+    const consoleError = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+
+    const [err, metadata] = await catchy(getMetadata(), undefined, true);
+    expect(err).toBeUndefined();
+    expect(metadata).toBe('metadata found!');
+    expect(consoleError).not.toHaveBeenCalled();
+
+    consoleError.mockRestore();
   });
 });

--- a/src/lib/catchy.test.ts
+++ b/src/lib/catchy.test.ts
@@ -31,7 +31,7 @@ describe('Catchy Module - Single Function', () => {
 });
 
 describe('Catchy Module - Multiple Functions', () => {
-  test('Given a multiple function calls, when some of them throw an error, then it should return the first error', async () => {
+  test('Given a multiple function calls, when some of them throw an error at the end, then it should return the error', async () => {
     const [errMetadata, metadata] = await catchy(getMetadata());
     expect(errMetadata).toBeUndefined();
     expect(metadata).toBe('metadata found!');
@@ -41,7 +41,7 @@ describe('Catchy Module - Multiple Functions', () => {
     expect(user).toBeUndefined();
   });
 
-  test('Given a multiple function calls, when some of them throw an error, then it should return the first error', async () => {
+  test('Given a multiple function calls, when some of them throw an error at the beginning, then it should return the error', async () => {
     const [errUser, user] = await catchy(getUser());
     expect(errUser).toBeInstanceOf(Error);
     expect(user).toBeUndefined();

--- a/src/lib/catchy.ts
+++ b/src/lib/catchy.ts
@@ -1,14 +1,20 @@
+/* eslint-disable curly */
+/* eslint-disable no-console */
+
 // this utility function wraps a promise and catches errors of a specific type.
 // it makes your code more catch-strict and less error - prone
 // since the `try-catch` must parse the errors to be caught
 async function catchy<T, E extends new (message?: string) => Error>(
   promise: Promise<T>,
   errsToCatch?: Array<E>,
+  verbose?: boolean,
 ): Promise<[undefined, T] | [InstanceType<E>]> {
   try {
     const v = await promise;
     return [undefined, v] as [undefined, T];
   } catch (err) {
+    if (verbose) console.error(err);
+
     if (errsToCatch === undefined) {
       return [err as InstanceType<E>];
     }

--- a/src/lib/catchy.ts
+++ b/src/lib/catchy.ts
@@ -1,6 +1,3 @@
-/* eslint-disable curly */
-/* eslint-disable no-console */
-
 // this utility function wraps a promise and catches errors of a specific type.
 // it makes your code more catch-strict and less error - prone
 // since the `try-catch` must parse the errors to be caught
@@ -13,6 +10,8 @@ async function catchy<T, E extends new (message?: string) => Error>(
     const v = await promise;
     return [undefined, v] as [undefined, T];
   } catch (err) {
+    /* eslint-disable curly */
+    /* eslint-disable no-console */
     if (verbose) console.error(err);
 
     if (errsToCatch === undefined) {

--- a/src/lib/catchy.ts
+++ b/src/lib/catchy.ts
@@ -18,7 +18,7 @@ async function catchy<T, E extends new (message?: string) => Error>(
       return [err as InstanceType<E>];
     }
 
-    if (errsToCatch.some((e) => err instanceof e)) {
+    if (errsToCatch.some((errType) => err instanceof errType)) {
       return [err as InstanceType<E>];
     }
 

--- a/src/lib/catchy.ts
+++ b/src/lib/catchy.ts
@@ -1,0 +1,24 @@
+// this utility function wraps a promise and catches errors of a specific type.
+// it makes your code more catch-strict and less error - prone
+// since the `try-catch` must parse the errors to be caught
+async function catchy<T, E extends new (message?: string) => Error>(
+  promise: Promise<T>,
+  errsToCatch?: Array<E>,
+): Promise<[undefined, T] | [InstanceType<E>]> {
+  try {
+    const v = await promise;
+    return [undefined, v] as [undefined, T];
+  } catch (err) {
+    if (errsToCatch === undefined) {
+      return [err as InstanceType<E>];
+    }
+
+    if (errsToCatch.some((e) => err instanceof e)) {
+      return [err as InstanceType<E>];
+    }
+
+    throw err;
+  }
+}
+
+export { catchy };

--- a/src/lib/catchy.ts
+++ b/src/lib/catchy.ts
@@ -14,11 +14,7 @@ async function catchy<T, E extends new (message?: string) => Error>(
     /* eslint-disable no-console */
     if (verbose) console.error(err);
 
-    if (errsToCatch === undefined) {
-      return [err as InstanceType<E>];
-    }
-
-    if (errsToCatch.some((errType) => err instanceof errType)) {
+    if (!errsToCatch || errsToCatch.some((errType) => err instanceof errType)) {
       return [err as InstanceType<E>];
     }
 


### PR DESCRIPTION
# Description
add custom catch including the unit test

## Background Summary
When the errors are returned to be general errors, we must parse them with additional catch-return specific types, it might need to be simpler by returning the first error (the goal is to reduce the error translation & parse).

## Output check
![image](https://github.com/user-attachments/assets/b8624fb3-fcf7-4001-9fe2-8aacbb776057)

![image](https://github.com/user-attachments/assets/d361ed86-acaa-400d-91e5-f18b4cf5f0cc)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new utility function for improved error handling in promise-based operations.
	- Added a testing script to the project for running unit tests using Jest.

- **Bug Fixes**
	- Enhanced the pre-commit process to run tests alongside linting, ensuring code quality before commits.

- **Tests**
	- Implemented comprehensive unit tests for the new utility function to validate its behavior with various promise scenarios.

- **Chores**
	- Updated project configuration with new dependencies and settings for Jest.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->